### PR TITLE
Removed delay after resetting ESP.

### DIFF
--- a/ESP_BaseCode/espduino.cpp
+++ b/ESP_BaseCode/espduino.cpp
@@ -191,7 +191,6 @@ void ESPduino::_debug(char* s){
   String cmd = "AT+RST";  
   _debug(cmd);
   _ESPSerial->println(cmd);  
-  delay(2000);
 
   // Search for a ready status
   if (_ESPSerial->find("ready")){


### PR DESCRIPTION
This was causing a bufferflow in the SoftwareSerial core lib. Workaround was to increase the RX buffer in the core lib. Since the RX buffer is circular, this modification to the core lib is no longer required to detect the 'ready' string and this delay can be safely omitted.